### PR TITLE
fix so it compiles on FreeBSD

### DIFF
--- a/mk/cflags.mk
+++ b/mk/cflags.mk
@@ -43,6 +43,9 @@ endif
 ifneq ($(filter Darwin%,$(shell uname)),)
   DARWIN=1
 endif
+ifneq ($(filter FreeBSD%,$(shell uname)),)
+  FREEBSD=1
+endif
 
 # Use pipes and not temp files.
 CFLAGSBASE += -pipe
@@ -98,6 +101,8 @@ CFLAGSBASE += -Wsequence-point
 CFLAGSBASE += -Wparentheses
 # warn about missing declarations
 CFLAGSBASE += -Wmissing-declarations
+# ports include directory for FreeBSD
+CFLAGSBASE += $(if $(FREEBSD),-I/usr/local/include)
 
 CFLAGS=$(CFLAGSBASE)
 LDFLAGS=$(LDFLAGSBASE)

--- a/mk/common.mk
+++ b/mk/common.mk
@@ -39,6 +39,7 @@ include $(__DIR__)/cflags.mk
 
 prefix      ?= /usr/local
 LDFLAGSBASE += $(if $(DARWIN),,-Wl,-warn-common)
+LDFLAGSBASE += $(if $(FREEBSD),-L/usr/local/lib)
 CFLAGSBASE  += --std=gnu99 -I../ -I../common
 ASCIIDOC     = asciidoc -f $(__DIR__)/asciidoc.conf -d manpage \
 	       -apft_version=$(shell git describe)

--- a/server.c
+++ b/server.c
@@ -344,8 +344,13 @@ listener_t *start_unix_listener(const char *socketfile)
     unlink(socketfile);
 
     old = umask(0111);
+#ifdef __FreeBSD__
+    strncpy(addr.sun_path, socketfile, 103);
+    addr.sun_path[103] = 0;
+#else
     strncpy(addr.sun_path, socketfile, 107);
     addr.sun_path[107] = 0;
+#endif
     sock = tcp_listen_nonblock((const struct sockaddr *)&addr, sizeof(addr));
     umask(old);
 


### PR DESCRIPTION
FreeBSD needs cflags -I/usr/local/include, and -L/usr/local/lib to find includes and libraries installed by ports (pcre, unbound, libev etc).

In addition, on FreeBSD, addr.sun_path is only 104 bytes long on FreeBSD.  Fixed with ifdef.
