### PR TITLE
Accept connections even when syncookies are disabled.

### DIFF
--- a/common.c
+++ b/common.c
@@ -123,7 +123,7 @@ int tcp_listen(const struct sockaddr *addr, socklen_t len)
     if (sock < 0) {
         return -1;
     }
-    if (listen(sock, 0) < 0) {
+    if (listen(sock, SOMAXCONN) < 0) {
         UNIXERR("bind");
         close(sock);
         return -1;
@@ -141,7 +141,7 @@ int tcp_listen_nonblock(const struct sockaddr *addr, socklen_t len)
         close(sock);
         return -1;
     }
-    if (listen(sock, 0) < 0) {
+    if (listen(sock, SOMAXCONN) < 0) {
         UNIXERR("bind");
         close(sock);
         return -1;

--- a/common.c
+++ b/common.c
@@ -90,6 +90,7 @@ int tcp_bind(const struct sockaddr *addr, socklen_t len)
         break;
       default:
         errno = EINVAL;
+        UNIXERR("addr");
         return -1;
     }
 
@@ -119,6 +120,9 @@ int tcp_bind(const struct sockaddr *addr, socklen_t len)
 int tcp_listen(const struct sockaddr *addr, socklen_t len)
 {
     int sock = tcp_bind(addr, len);
+    if (sock < 0) {
+        return -1;
+    }
     if (listen(sock, 0) < 0) {
         UNIXERR("bind");
         close(sock);
@@ -130,6 +134,9 @@ int tcp_listen(const struct sockaddr *addr, socklen_t len)
 int tcp_listen_nonblock(const struct sockaddr *addr, socklen_t len)
 {
     int sock = tcp_bind(addr, len);
+    if (sock < 0) {
+        return -1;
+    }
     if (setnonblock(sock)) {
         close(sock);
         return -1;

--- a/server.c
+++ b/server.c
@@ -337,8 +337,6 @@ listener_t *start_unix_listener(const char *socketfile)
     int sock;
     mode_t old;
 
-    unlink(socketfile);
-
     old = umask(0111);
     strncpy(addr.sun_path, socketfile, sizeof(addr.sun_path) - 1);
     addr.sun_path[sizeof(addr.sun_path) - 1] = 0;


### PR DESCRIPTION
The backlog argument of listen() should not be zero when syncookies are disabled (since Linux 2.2).
